### PR TITLE
Fixups for !stonks

### DIFF
--- a/src/Huntress/Plugin/Stonks.php
+++ b/src/Huntress/Plugin/Stonks.php
@@ -29,6 +29,8 @@ class Stonks implements PluginInterface
 
     public const CACHE_TTL = 300;
 
+    public const MAX_SYMBOLS = 5;
+
     /**
      * @var \Aran\YahooFinanceApi\ApiClient
      */
@@ -38,13 +40,13 @@ class Stonks implements PluginInterface
     private array $cache;
 
     /** @var int */
-    private int $ttl;
+    private int $cache_ttl;
 
     public function __construct(Huntress $bot)
     {
         $this->client = ApiClientFactory::createFromLoop($bot->getLoop());
         $this->cache = [];
-        $this->ttl = static::CACHE_TTL;
+        $this->cache_ttl = static::CACHE_TTL;
     }
 
     public static function register(Huntress $bot): void
@@ -69,7 +71,7 @@ class Stonks implements PluginInterface
         // Check which quotes must be refreshed.
         $refresh = array_filter($symbols, fn($symbol) => (
             !isset($this->cache[$symbol]) ||
-            $this->cache[$symbol]['time'] + $this->ttl < $now
+            $this->cache[$symbol]['time'] + $this->cache_ttl < $now
         ));
 
         $channel = $event->message->channel;

--- a/src/Huntress/Plugin/Stonks.php
+++ b/src/Huntress/Plugin/Stonks.php
@@ -111,9 +111,14 @@ class Stonks implements PluginInterface
         });
     }
 
-    public function search(EventData $event): PromiseInterface {
+    public function search(EventData $event): ?PromiseInterface {
         $search = self::arg_substr($event->message->content, 2);
         $channel = $event->message->channel;
+
+        // Refuse to search for an empty string.
+        if (!$search) {
+            return NULL;
+        }
 
         return $channel->send('Searching...')
             ->then(fn() => $this->client->search($search))

--- a/src/Huntress/Plugin/Stonks.php
+++ b/src/Huntress/Plugin/Stonks.php
@@ -101,7 +101,7 @@ class Stonks implements PluginInterface
                 if (isset($this->cache[$symbol])) {
                     /** @var \Aran\YahooFinanceApi\Results\Quote $quote */
                     ['time' => $time, 'quote' => $quote] = $this->cache[$symbol];
-                    $promises[] = $channel->send('', ['embed' => $this->formatQuote($symbol, $quote, $time)]);
+                    $promises[] = $channel->send('', ['embed' => $this->formatQuote($quote, $time)]);
                 }
                 else {
                     $promises[] = $channel->send(sprintf("No results returned for $symbol"));
@@ -131,10 +131,10 @@ class Stonks implements PluginInterface
             });
     }
 
-    private function formatQuote(string $symbol, Quote $quote, int $time): MessageEmbed {
+    private function formatQuote(Quote $quote, int $time): MessageEmbed {
         $currency = $quote->getCurrency();
         $embed = new MessageEmbed();
-        $embed->setTitle("{$symbol} ({$quote->getFullExchangeName()})");
+        $embed->setTitle("{$quote->getSymbol()} ({$quote->getFullExchangeName()})");
         $embed->addField(
             'Ask / Bid',
             "{$currency} {$quote->getAsk()} / {$currency} {$quote->getBid()}"

--- a/src/Huntress/Plugin/Stonks.php
+++ b/src/Huntress/Plugin/Stonks.php
@@ -42,16 +42,16 @@ class Stonks implements PluginInterface
     /** @var int */
     private int $cache_ttl;
 
-    public function __construct(Huntress $bot)
+    public function __construct(Huntress $bot, int $cache_ttl)
     {
         $this->client = ApiClientFactory::createFromLoop($bot->getLoop());
         $this->cache = [];
-        $this->cache_ttl = static::CACHE_TTL;
+        $this->cache_ttl = $cache_ttl;
     }
 
     public static function register(Huntress $bot): void
     {
-        $instance = new static($bot);
+        $instance = new static($bot, static::CACHE_TTL);
         $bot->eventManager->addEventListener(
             EventListener::new()
                 ->addCommand('stonks')

--- a/src/Huntress/Plugin/Stonks.php
+++ b/src/Huntress/Plugin/Stonks.php
@@ -125,7 +125,11 @@ class Stonks implements PluginInterface
             ->then(function ($results) use ($search, $channel) {
                 $embed = new MessageEmbed();
                 $count = count($results);
-                $embed->setTitle("{$count} results for \"*{$search}*\"");
+                $embed->setTitle(sprintf(
+                    '%d results for "*%s*"',
+                    $count,
+                    addcslashes($search, '*\\')
+                ));
                 foreach ($results as $result) {
                     $embed->addField(
                         $result->getSymbol(),

--- a/src/Huntress/Plugin/Stonks.php
+++ b/src/Huntress/Plugin/Stonks.php
@@ -158,34 +158,49 @@ class Stonks implements PluginInterface
         $currency = $quote->getCurrency();
         $embed = new MessageEmbed();
         $embed->setTitle("{$quote->getSymbol()} ({$quote->getFullExchangeName()})");
-        $embed->addField(
-            'Ask / Bid',
-            "{$currency} {$quote->getAsk()} / {$currency} {$quote->getBid()}"
-        );
         if ($quote->getMarketState()) {
             $embed->addField(
                 'Market state',
                 $quote->getMarketState()
             );
         }
-        $embed->addField(
-            'Opening price',
-            sprintf('%s %.2f', $currency, $quote->getRegularMarketOpen())
-        );
-        $embed->addField(
-            $quote->getMarketState() === 'REGULAR' ? 'Market price' : 'Closing price',
-            sprintf(
-                '%s %.2f, (%+.3f%%)',
-                $currency, $quote->getRegularMarketPrice(),
-                $quote->getRegularMarketChangePercent()
-            )
-        );
+        if ($quote->getRegularMarketPreviousClose()) {
+            $embed->addField(
+                'Previous closing price',
+                sprintf("{$currency} %.2f", $quote->getRegularMarketPreviousClose())
+            );
+        }
+        if ($quote->getRegularMarketOpen()) {
+            $embed->addField(
+                'Opening price',
+                sprintf("{$currency} %.2f", $quote->getRegularMarketOpen())
+            );
+        }
+        if ($quote->getRegularMarketPrice()) {
+            $embed->addField(
+                $quote->getMarketState() === 'REGULAR' ? 'Market price' : 'Closing price',
+                sprintf(
+                    "{$currency} %.2f, (%+.3f%%)",
+                    $quote->getRegularMarketPrice(),
+                    $quote->getRegularMarketChangePercent()
+                )
+            );
+        }
+        if ($quote->getRegularMarketDayLow() && $quote->getRegularMarketDayHigh()) {
+            $embed->addField(
+                'Day Low / Day High',
+                sprintf(
+                    "{$currency} %.2f / {$currency} %.2f",
+                    $quote->getRegularMarketDayLow(),
+                    $quote->getRegularMarketDayHigh()
+                )
+            );
+        }
         if ($quote->getPostMarketPrice()) {
             $embed->addField(
                 'Post-Market price',
                 sprintf(
-                    '%s %.2f, (%+.3f%%)',
-                    $currency,
+                    "{$currency} %.2f, (%+.3f%%)",
                     $quote->getPostMarketPrice(),
                     $quote->getPostMarketChangePercent()
                 )
@@ -195,10 +210,19 @@ class Stonks implements PluginInterface
             $embed->addField(
                 'Pre-Market price',
                 sprintf(
-                    '%s %.2f, (%+.3f%%)',
-                    $currency,
+                    "{$currency} %.2f, (%+.3f%%)",
                     $quote->getPreMarketPrice(),
                     $quote->getPreMarketChangePercent()
+                )
+            );
+        }
+        if ($quote->getAsk() && $quote->getBid()) {
+            $embed->addField(
+                'Ask / Bid',
+                sprintf(
+                    "{$currency} %.2f / {$currency} %.2f",
+                    $quote->getAsk(),
+                    $quote->getBid()
                 )
             );
         }


### PR DESCRIPTION
Basically:

- add a permission
- clean up output (escape '*', suppress empty search, etc)
- improve card (add previous close and day low/high, check data exists before printing it, etc)
- limit simultaneous lookups to 5 per message (really easy to spam up the channel otherwise)
- general cleanup+comments ❤️ 